### PR TITLE
fix: Look for a halt file in the right place in scr_retries_halt

### DIFF
--- a/src/scr_retries_halt.c
+++ b/src/scr_retries_halt.c
@@ -33,7 +33,7 @@
 #include <sys/time.h>
 
 #define PROG ("scr_retries_halt")
-#define NAME ("halt.scr")
+#define NAME (".scr/halt.scr")
 #define NEED_HALT (0)
 #define DONT_HALT (1)
 


### PR DESCRIPTION
Previously it was looking for a halt file in $PREFIX/halt.scr. But the
file is located in $PREFIX/.scr/halt.scr